### PR TITLE
Handle series_id not being returned by get_series_info & extra standardization

### DIFF
--- a/src/serializers/jsonapi.ts
+++ b/src/serializers/jsonapi.ts
@@ -120,6 +120,7 @@ export const JSONAPISerializer = defineSerializers('JSON:API', {
           cast,
           director,
           youtubeTrailer,
+          title,
           ...cced
         } = movie;
 
@@ -128,6 +129,7 @@ export const JSONAPISerializer = defineSerializers('JSON:API', {
           id: streamId.toString(),
           attributes: {
             ...cced,
+            name: title,
             genre: genre.split(',').map((x) => x.trim()),
             cast: cast.split(',').map((x) => x.trim()),
             director: director.split(',').map((x) => x.trim()),
@@ -173,12 +175,13 @@ export const JSONAPISerializer = defineSerializers('JSON:API', {
       movieImage,
       backdropPath,
       ratingCountKinopoisk,
+      kinopoiskUrl,
       episodeRunTime,
       youtubeTrailer,
       tmdbId,
       ...restInfo
     } = camelInput.info;
-    const { categoryId, categoryIds, streamId, added, ...restData } = camelInput.movieData;
+    const { categoryId, categoryIds, streamId, added, title, ...restData } = camelInput.movieData;
 
     return {
       data: {
@@ -187,7 +190,7 @@ export const JSONAPISerializer = defineSerializers('JSON:API', {
         attributes: {
           ...restData,
           ...restInfo,
-          informationUrl: restInfo.kinopoiskUrl,
+          informationUrl: kinopoiskUrl,
           originalName: oName,
           cover: coverBig,
           poster: movieImage,
@@ -305,6 +308,10 @@ export const JSONAPISerializer = defineSerializers('JSON:API', {
       ...restShowInfo
     } = info;
 
+    if (typeof seriesId === 'undefined') {
+      throw new Error('seriesId is required');
+    }
+
     const flatEpisodes = Object.values(episodes).flat();
 
     const episodesAsJSONAPI: JSONAPIXtreamEpisode[] = flatEpisodes.map((episode) => {
@@ -394,7 +401,7 @@ export const JSONAPISerializer = defineSerializers('JSON:API', {
     return {
       data: {
         type: 'show',
-        id: info.seriesId.toString(),
+        id: seriesId.toString(),
         attributes: {
           ...restShowInfo,
           voteAverage: Number(rating),

--- a/src/serializers/standardized.ts
+++ b/src/serializers/standardized.ts
@@ -95,12 +95,14 @@ export const standardizedSerializer = defineSerializers('Standardized', {
         cast,
         director,
         youtubeTrailer,
+        title,
         ...cced
       } = movie;
 
       return {
         id: streamId.toString(),
         ...cced,
+        name: title,
         genre: genre.split(',').map((x) => x.trim()),
         cast: cast.split(',').map((x) => x.trim()),
         director: director.split(',').map((x) => x.trim()),
@@ -135,16 +137,17 @@ export const standardizedSerializer = defineSerializers('Standardized', {
       movieImage,
       backdropPath,
       ratingCountKinopoisk,
+      kinopoiskUrl,
       episodeRunTime,
       youtubeTrailer,
       tmdbId,
       ...restInfo
     } = camelInput.info;
-    const { categoryId, categoryIds, streamId, added, ...restData } = camelInput.movieData;
+    const { categoryId, categoryIds, streamId, added, title, ...restData } = camelInput.movieData;
 
     return {
       id: streamId.toString(),
-      informationUrl: restInfo.kinopoiskUrl,
+      informationUrl: kinopoiskUrl,
       originalName: oName,
       cover: coverBig,
       poster: movieImage,
@@ -235,6 +238,10 @@ export const standardizedSerializer = defineSerializers('Standardized', {
       ...restShowInfo
     } = info;
 
+    if (typeof seriesId === 'undefined') {
+      throw new Error('seriesId is required');
+    }
+
     const flatEpisodes = Object.values(episodes).flat();
 
     const mappedEpisodes: StandardXtreamEpisode[] = flatEpisodes.map((episode) => {
@@ -297,7 +304,7 @@ export const standardizedSerializer = defineSerializers('Standardized', {
     });
 
     return {
-      id: info.seriesId.toString(),
+      id: seriesId.toString(),
       ...restShowInfo,
       voteAverage: Number(rating),
       poster: cover,

--- a/src/types.ts
+++ b/src/types.ts
@@ -355,8 +355,8 @@ export type XtreamShowInfo = {
   title: string;
   /** The year of release */
   year: string;
-  /** The unique identifier for the series */
-  series_id: number;
+  /** The unique identifier for the series, added by this library */
+  series_id?: number;
   /** The URL for the show's cover image */
   cover: string;
   /** The synopsis/description of the show */

--- a/src/xtream.ts
+++ b/src/xtream.ts
@@ -509,6 +509,8 @@ export class Xtream<T extends CustomSerializers = CustomSerializers> {
       throw new Error('Show Not Found');
     }
 
+    show.info.series_id = Number(showId);
+
     Object.keys(show.episodes).forEach((season) => {
       show.episodes[season].forEach((episode) => {
         episode.url = this.generateStreamUrl({

--- a/tests/msw.ts
+++ b/tests/msw.ts
@@ -304,7 +304,6 @@ const show: XtreamShow = {
     episode_run_time: '37',
     category_id: '2',
     category_ids: [2],
-    series_id: 16083,
   },
   episodes: {
     '1': [

--- a/tests/snapshots/camelcase/show.json
+++ b/tests/snapshots/camelcase/show.json
@@ -45,7 +45,7 @@
     "categoryIds": [
       2
     ],
-    "seriesId": 16083
+    "seriesId": 1
   },
   "episodes": {
     "1": [

--- a/tests/snapshots/jsonapi/movie.json
+++ b/tests/snapshots/jsonapi/movie.json
@@ -4,12 +4,10 @@
     "id": "100000",
     "attributes": {
       "name": "Movie Title",
-      "title": "Movie Title",
       "year": "2023",
       "containerExtension": "mp4",
       "customSid": "abc123",
       "directSource": "https://example.com/streaming/movie.mp4",
-      "kinopoiskUrl": "https://www.example.com/movie/123456",
       "description": "A brief description of the movie plot that gives viewers an idea of what the film is about without revealing too many details.",
       "plot": "A more detailed description of the movie plot that explains the main storyline and characters.",
       "country": "United States",

--- a/tests/snapshots/jsonapi/movies.json
+++ b/tests/snapshots/jsonapi/movies.json
@@ -4,8 +4,7 @@
       "type": "movie",
       "id": "935703",
       "attributes": {
-        "name": "Summer Adventure (2024)",
-        "title": "Summer Adventure",
+        "name": "Summer Adventure",
         "year": "2024",
         "plot": "Four friends embark on an unforgettable journey across the coast during their last summer together before college.",
         "containerExtension": "mp4",
@@ -48,8 +47,7 @@
       "type": "movie",
       "id": "935704",
       "attributes": {
-        "name": "The Last Stand (2023)",
-        "title": "The Last Stand",
+        "name": "The Last Stand",
         "year": "2023",
         "plot": "A retired sheriff and his team must protect their town from a ruthless cartel leader and his gang.",
         "containerExtension": "mp4",

--- a/tests/snapshots/jsonapi/show-no-seasons.json
+++ b/tests/snapshots/jsonapi/show-no-seasons.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "type": "show",
-    "id": "16083",
+    "id": "3000",
     "attributes": {
       "name": "Small Town Stories (2025)",
       "title": "Small Town Stories",
@@ -77,7 +77,7 @@
         "show": {
           "data": {
             "type": "show",
-            "id": "16083"
+            "id": "3000"
           }
         },
         "episodes": {
@@ -127,7 +127,7 @@
         "show": {
           "data": {
             "type": "show",
-            "id": "16083"
+            "id": "3000"
           }
         }
       }
@@ -165,7 +165,7 @@
         "show": {
           "data": {
             "type": "show",
-            "id": "16083"
+            "id": "3000"
           }
         }
       }

--- a/tests/snapshots/jsonapi/show.json
+++ b/tests/snapshots/jsonapi/show.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "type": "show",
-    "id": "16083",
+    "id": "1",
     "attributes": {
       "name": "Small Town Stories (2025)",
       "title": "Small Town Stories",
@@ -81,7 +81,7 @@
         "show": {
           "data": {
             "type": "show",
-            "id": "16083"
+            "id": "1"
           }
         },
         "episodes": {
@@ -105,7 +105,7 @@
         "show": {
           "data": {
             "type": "show",
-            "id": "16083"
+            "id": "1"
           }
         },
         "episodes": {
@@ -155,7 +155,7 @@
         "show": {
           "data": {
             "type": "show",
-            "id": "16083"
+            "id": "1"
           }
         }
       }
@@ -193,7 +193,7 @@
         "show": {
           "data": {
             "type": "show",
-            "id": "16083"
+            "id": "1"
           }
         }
       }

--- a/tests/snapshots/raw/show.json
+++ b/tests/snapshots/raw/show.json
@@ -46,7 +46,7 @@
     "category_ids": [
       2
     ],
-    "series_id": 16083
+    "series_id": 1
   },
   "episodes": {
     "1": [

--- a/tests/snapshots/standardized/movie.json
+++ b/tests/snapshots/standardized/movie.json
@@ -41,12 +41,10 @@
     "age": null
   },
   "name": "Movie Title",
-  "title": "Movie Title",
   "year": "2023",
   "containerExtension": "mp4",
   "customSid": "abc123",
   "directSource": "https://example.com/streaming/movie.mp4",
-  "kinopoiskUrl": "https://www.example.com/movie/123456",
   "description": "A brief description of the movie plot that gives viewers an idea of what the film is about without revealing too many details.",
   "plot": "A more detailed description of the movie plot that explains the main storyline and characters.",
   "country": "United States",

--- a/tests/snapshots/standardized/movies.json
+++ b/tests/snapshots/standardized/movies.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "935703",
-    "name": "Summer Adventure (2024)",
-    "title": "Summer Adventure",
+    "name": "Summer Adventure",
     "year": "2024",
     "plot": "Four friends embark on an unforgettable journey across the coast during their last summer together before college.",
     "containerExtension": "mp4",
@@ -35,8 +34,7 @@
   },
   {
     "id": "935704",
-    "name": "The Last Stand (2023)",
-    "title": "The Last Stand",
+    "name": "The Last Stand",
     "year": "2023",
     "plot": "A retired sheriff and his team must protect their town from a ruthless cartel leader and his gang.",
     "containerExtension": "mp4",

--- a/tests/snapshots/standardized/show-no-seasons.json
+++ b/tests/snapshots/standardized/show-no-seasons.json
@@ -1,5 +1,5 @@
 {
-  "id": "16083",
+  "id": "3000",
   "name": "Small Town Stories (2025)",
   "title": "Small Town Stories",
   "year": "2025",
@@ -38,7 +38,7 @@
       "releaseDate": "2025-02-24T00:00:00.000Z",
       "number": 1,
       "cover": "https://example-iptv.com/images/small-town-s01e01.jpg",
-      "showId": "16083",
+      "showId": "3000",
       "episodes": [
         {
           "id": "935666",
@@ -60,7 +60,7 @@
           "durationFormatted": "00:36:54",
           "releaseDate": "2025-02-24T00:00:00.000Z",
           "createdAt": "2025-02-25T17:15:21.000Z",
-          "showId": "16083",
+          "showId": "3000",
           "seasonId": "1"
         },
         {
@@ -83,7 +83,7 @@
           "durationFormatted": "00:36:49",
           "releaseDate": "2025-02-25T00:00:00.000Z",
           "createdAt": "2025-02-26T17:35:20.000Z",
-          "showId": "16083",
+          "showId": "3000",
           "seasonId": "1"
         }
       ]

--- a/tests/snapshots/standardized/show.json
+++ b/tests/snapshots/standardized/show.json
@@ -1,5 +1,5 @@
 {
-  "id": "16083",
+  "id": "1",
   "name": "Small Town Stories (2025)",
   "title": "Small Town Stories",
   "year": "2025",
@@ -38,7 +38,7 @@
       "releaseDate": "2025-02-17T00:00:00.000Z",
       "number": 0,
       "cover": "https://example-iptv.com/images/small-town-specials-large.jpg",
-      "showId": "16083",
+      "showId": "1",
       "episodes": []
     },
     {
@@ -50,7 +50,7 @@
       "releaseDate": "2025-02-24T00:00:00.000Z",
       "number": 1,
       "cover": "https://example-iptv.com/images/small-town-s1-large.jpg",
-      "showId": "16083",
+      "showId": "1",
       "episodes": [
         {
           "id": "935666",
@@ -72,7 +72,7 @@
           "durationFormatted": "00:36:54",
           "releaseDate": "2025-02-24T00:00:00.000Z",
           "createdAt": "2025-02-25T17:15:21.000Z",
-          "showId": "16083",
+          "showId": "1",
           "seasonId": "382546"
         },
         {
@@ -95,7 +95,7 @@
           "durationFormatted": "00:36:49",
           "releaseDate": "2025-02-25T00:00:00.000Z",
           "createdAt": "2025-02-26T17:35:20.000Z",
-          "showId": "16083",
+          "showId": "1",
           "seasonId": "382546"
         }
       ]


### PR DESCRIPTION
- series_id is not returned by xtream for get_series_info
- some movie keys were not removed in serializer
- standardize on name key only for movies