### PR TITLE
Enhancement: change preferredFormat to a union instead of string

### DIFF
--- a/src/xtream.ts
+++ b/src/xtream.ts
@@ -38,8 +38,6 @@ type Serializers = {
  */
 type CustomSerializers = Partial<Serializers>;
 
-export type PreferredFormat = 'ts' | 'm3u8' | 'rtmp';
-
 /**
  * Configuration options for initializing the Xtream API client.
  * @property url - Base URL of the Xtream API server
@@ -51,7 +49,7 @@ type Options = {
   url: string;
   username: string;
   password: string;
-  preferredFormat?: PreferredFormat;
+  preferredFormat?: 'ts' | 'm3u8' | 'rtmp';
 };
 
 /**

--- a/src/xtream.ts
+++ b/src/xtream.ts
@@ -38,6 +38,8 @@ type Serializers = {
  */
 type CustomSerializers = Partial<Serializers>;
 
+export type PreferredFormat = 'ts' | 'm3u8' | 'rtmp';
+
 /**
  * Configuration options for initializing the Xtream API client.
  * @property url - Base URL of the Xtream API server
@@ -49,7 +51,7 @@ type Options = {
   url: string;
   username: string;
   password: string;
-  preferredFormat?: string;
+  preferredFormat?: PreferredFormat;
 };
 
 /**

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4,7 +4,6 @@ import { camelCaseSerializer } from '../src/serializers/camelcase.ts';
 import { JSONAPISerializer } from '../src/serializers/jsonapi.ts';
 import { standardizedSerializer } from '../src/serializers/standardized.ts';
 import { server } from './msw.ts';
-import { PreferredFormat } from 'src/xtream.ts';
 
 // Setup MSW
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -220,7 +219,8 @@ describe('Xtream API', () => {
       url: 'http://example.com',
       username: 'test',
       password: 'password',
-      preferredFormat: 'nono' as PreferredFormat,
+      // @ts-expect-error: this should fail due to type checking
+      preferredFormat: 'nono',
     });
 
     const stream = await formatXtream.getChannels({ page: 1, limit: 1 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4,6 +4,7 @@ import { camelCaseSerializer } from '../src/serializers/camelcase.ts';
 import { JSONAPISerializer } from '../src/serializers/jsonapi.ts';
 import { standardizedSerializer } from '../src/serializers/standardized.ts';
 import { server } from './msw.ts';
+import { PreferredFormat } from 'src/xtream.ts';
 
 // Setup MSW
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -219,7 +220,7 @@ describe('Xtream API', () => {
       url: 'http://example.com',
       username: 'test',
       password: 'password',
-      preferredFormat: 'nono',
+      preferredFormat: 'nono' as PreferredFormat,
     });
 
     const stream = await formatXtream.getChannels({ page: 1, limit: 1 });


### PR DESCRIPTION
This PR changes the `preferredFormat` property in Xtream API Client options to a union with the following values: `ts`, `m3u8`, `rtmp`
Instead of a plain string, the developer would now know what are the potential values for this property which enhances DX